### PR TITLE
Add dynamic billionaire selection and CPI items

### DIFF
--- a/data/cpi_items.json
+++ b/data/cpi_items.json
@@ -1,0 +1,18 @@
+[
+  {"name": "Loaf of Bread", "price": 3},
+  {"name": "Gallon of Milk", "price": 4},
+  {"name": "Dozen Eggs", "price": 5},
+  {"name": "Pound of Chicken", "price": 6},
+  {"name": "Coffee (1 lb)", "price": 8},
+  {"name": "Monthly Rent", "price": 1300},
+  {"name": "Electricity Bill", "price": 120},
+  {"name": "Natural Gas Bill", "price": 90},
+  {"name": "Bus Fare", "price": 3},
+  {"name": "Gasoline (gallon)", "price": 3.8},
+  {"name": "Doctor Visit", "price": 150},
+  {"name": "Prescription Drugs", "price": 50},
+  {"name": "Movie Ticket", "price": 12},
+  {"name": "College Tuition (year)", "price": 12000},
+  {"name": "Cell Phone Plan", "price": 70},
+  {"name": "Haircut", "price": 25}
+]

--- a/data/richest_people.json
+++ b/data/richest_people.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Bernard Arnault",
+    "net_worth": 210000000000
+  },
+  {
+    "name": "Elon Musk",
+    "net_worth": 200000000000
+  },
+  {
+    "name": "Jeff Bezos",
+    "net_worth": 190000000000
+  },
+  {
+    "name": "Larry Ellison",
+    "net_worth": 155000000000
+  },
+  {
+    "name": "Mark Zuckerberg",
+    "net_worth": 150000000000
+  },
+  {
+    "name": "Bill Gates",
+    "net_worth": 130000000000
+  },
+  {
+    "name": "Warren Buffett",
+    "net_worth": 120000000000
+  },
+  {
+    "name": "Larry Page",
+    "net_worth": 115000000000
+  },
+  {
+    "name": "Sergey Brin",
+    "net_worth": 110000000000
+  },
+  {
+    "name": "Steve Ballmer",
+    "net_worth": 105000000000
+  }
+]

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta
       name="description"
-      content="The most popular simulator on spending Elon's Billions. Can you spend it all?"
+      content="A simulator for spending the fortunes of the world's richest people. Can you spend it all?"
     />
     <!-- Google Analytics -->
     <script
@@ -28,7 +28,7 @@
       crossorigin="anonymous"
     ></script>
 
-    <title>Spend Elon Musk's Money</title>
+    <title>Spend a Billionaire's Money</title>
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="./img/usd-circle.svg" />
   </head>
@@ -36,15 +36,15 @@
     <header>
       <img src="https://i.imgur.com/sroyZau.jpg" alt="" />
       <div class="title-container">
-        <h1>Spend Elon Musk's Fortune!</h1>
+        <h1>Spend a Billionaire's Fortune!</h1>
         <p>
-          If Elon cashed out all of his stocks & assets today he would have
-          <br />
-          approximately <strong>$245,000,000,000</strong> (US Dollars) in his
-          bank account (Forbes 2024).
+          Select from the richest people on earth and see if you can spend their
+          fortune.
         </p>
         <p>¿What would you <strong>spend it</strong> on?</p>
         <p>¡Have your receipt at the end!</p>
+        <label for="personSelect">Choose a fortune:</label>
+        <select id="personSelect"></select>
       </div>
     </header>
 
@@ -67,8 +67,8 @@
     </script>
     <!-- AD TEST END -->
 
-    <div class="total">
-      <p class="totalMoney" id="totalMoney">Remaining: $245,000,000,000</p>
+      <div class="total">
+        <p class="totalMoney" id="totalMoney">Remaining: Loading...</p>
       <p class="percentageLeft" id="percentageLeft">
         You haven't spent a single dollar! start buying!
       </p>


### PR DESCRIPTION
## Summary
- fetch top 10 billionaires from `data/richest_people.json`
- allow the user to select a billionaire fortune via a dropdown
- load CPI basket items from `data/cpi_items.json`
- adjust totals and receipt calculations to work with the selected fortune
- render all items dynamically
- update page text to be billionaire‑agnostic

## Testing
- `node -c code.js`

------
https://chatgpt.com/codex/tasks/task_e_68700aedd16483278c5a9f215620cd37